### PR TITLE
removeAssets also removes chunks if present

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -84,16 +84,29 @@ module.exports = class SpikeUtils {
    *
    * @param {Object} compilation - webpack compilation object from plugin
    * @param {Array|String} _files - path(s) to source files, relative/absolute
+   * @param {Array} [chunks] - webpack chunks object
    * @param {Function} done - callback
    */
-  removeAssets (compilation, _files) {
-    let files = Array.prototype.concat(_files).map((f) => {
-      const file = new File(this.conf.context, f)
-      return `${file.relative}.js`
+  removeAssets (compilation, _files, chunks) {
+    const files = Array.prototype.concat(_files).map((f) => {
+      return (new File(this.conf.context, f)).relative
     })
 
+    // first we remove the files from webpack's `assets`
+    const filesDotJs = files.map((f) => `${f}.js`)
     for (const a in compilation.assets) {
-      if (files.indexOf(a) > -1) { delete compilation.assets[a] }
+      if (filesDotJs.indexOf(a) > -1) { delete compilation.assets[a] }
+    }
+
+    // Now we remove any chunks that are not further processed.
+    // Directly modifying the webpack object is tricky, we need a mutating
+    // method (splice), and we need the mutations not to affect the indices,
+    // hence the reverse.
+    if (chunks) {
+      const staticChunks = chunks.reduce((m, c, i) => {
+        if (files.indexOf(c.name) > -1) m.push(i); return m
+      }, [])
+      staticChunks.reverse().forEach((i) => chunks.splice(i, 1))
     }
   }
 

--- a/test/index.js
+++ b/test/index.js
@@ -41,7 +41,8 @@ test.cb('EVERYTHING WORKS', (t) => {
       { test: /\.txt$/, loader: 'source' }
     ]},
     ignore: ['**/views/ignoreme.txt'],
-    plugins: [plugin]
+    plugins: [plugin],
+    devtool: 'source-map'
   })
 
   project.on('error', t.fail)

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -24,7 +24,7 @@ module.exports = class TestPlugin extends EventEmitter {
 
     compiler.plugin('compilation', (compilation) => {
       compilation.plugin('optimize-chunk-assets', (chunks, done) => {
-        this.util.removeAssets(compilation, this.injectFile)
+        this.util.removeAssets(compilation, this.injectFile, chunks)
         this.emit('removeAssets')
         done()
       })


### PR DESCRIPTION
So at the moment, if you try to generate any type of sourcemaps through spike, we get a pretty nasty error and the entire compile breaks. I figure we probably don't want this to be the case, so I dug into webpack's core to try to figure out where the error is coming from.

Long story short, I figured it out, and it's because when we remove assets that we have processed, we need to remove them not only from the webpack `assets` object internally, which is used to determine where to write files (since we write them ourselves), but also from an internal structure called `chunks`, or else webpack tries to generate sourcemaps for them as javascript files and just breaks because they aren't really js files, and the way we load them into and out of the pipeline is super unconventional, and it can't handle this.

So if we update to this new method in spike-core, it will generate a sourcemap without error for all javascript files, and generate nothing for the static, html, and css files as we generally want to be the case.
