### PR TITLE
Make removeAssets more flexible

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -121,9 +121,14 @@ module.exports = class SpikeUtils {
     })
 
     // first we remove the files from webpack's `assets`
-    const filesDotJs = files.map((f) => `${f}.js`)
-    for (const a in compilation.assets) {
-      if (filesDotJs.indexOf(a) > -1) { delete compilation.assets[a] }
+    const chunksByName = compilation.records.chunks.byName
+    const chunkNames = Object.keys(compilation.assets)
+    for (let k in chunksByName) {
+      // if the chunk name is in our spike-processed files, we remove
+      // that chunk from the assets to be written
+      if (files.indexOf(k) > -1) {
+        delete compilation.assets[chunkNames[chunksByName[k]]]
+      }
     }
 
     // Now we remove any chunks that are not further processed.


### PR DESCRIPTION
`removeAssets` previously relied on webpack setting processing files by name. Using a slightly different technique, this allows for assets to be found and removed no matter how they are output, whether by name, hash, id, etc.

This is the first step in moving towards allowing spike to be able to output aggressively split, hashed javascript assets.